### PR TITLE
new basemap control

### DIFF
--- a/packages/massmapper-app/leaflet.css
+++ b/packages/massmapper-app/leaflet.css
@@ -1,0 +1,4 @@
+.leaflet-touch .leaflet-control-layers-toggle {
+    width: 32px;
+    height: 32px;
+}

--- a/packages/massmapper-app/leaflet.css
+++ b/packages/massmapper-app/leaflet.css
@@ -1,4 +1,9 @@
+.leaflet-touch .leaflet-control-layers, .leaflet-touch .leaflet-bar {
+    border: none;
+}
+
 .leaflet-touch .leaflet-control-layers-toggle {
-    width: 32px;
+    width: 64px;
     height: 32px;
+    box-shadow: 0px 3px 1px -2px rgb(0 0 0 / 20%), 0px 2px 2px 0px rgb(0 0 0 / 14%), 0px 1px 5px 0px rgb(0 0 0 / 12%);
 }

--- a/packages/massmapper-app/src/MassMapperApp.tsx
+++ b/packages/massmapper-app/src/MassMapperApp.tsx
@@ -20,6 +20,7 @@ import CatalogComponent from './components/CatalogComponent';
 import { useService } from './services/useService';
 
 import 'leaflet/dist/leaflet.css';
+import '../leaflet.css';
 
 import massmapper from './images/massmapper.png';
 import SplashPageModal from './components/SplashPageModal';

--- a/packages/massmapper-app/src/services/MapService.ts
+++ b/packages/massmapper-app/src/services/MapService.ts
@@ -61,10 +61,17 @@ class MapService {
 			this._mapZoom = this._map?.getZoom() || 0;
 		});
 
-		// TODO:  Unhardcode this?
-		m.addLayer(new TileLayer(
-			'https://tiles.arcgis.com/tiles/hGdibHYSPO59RG1h/arcgis/rest/services/MassGIS_Topographic_Features_for_Basemap/MapServer/tile/{z}/{y}/{x}'
-		));
+		new Control.Layers(
+			{
+				'MassGIS Statewide Basemap' : new TileLayer(
+					'https://tiles.arcgis.com/tiles/hGdibHYSPO59RG1h/arcgis/rest/services/MassGIS_Topographic_Features_for_Basemap/MapServer/tile/{z}/{y}/{x}'
+				).addTo(this._map),
+				'OpenStreeMap Basemap': new TileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+					maxZoom: 19,
+					attribution: '&copy; <a href="https://openstreetmap.org/copyright">OpenStreetMap contributors</a>'
+				})
+			}
+		).addTo(this._map);
 
 		// after every change to the enabledLayers, sync the layer list to the map
 		autorun(() => {


### PR DESCRIPTION
@sfarber I thought I'd let Leaflet do the heavy lifting here.

![image](https://user-images.githubusercontent.com/180985/119008592-4f197700-b960-11eb-85ea-bf1add29b689.png)

![image](https://user-images.githubusercontent.com/180985/119008613-5476c180-b960-11eb-8a59-9dfaddabeda6.png)

In order to add Google basemaps, it looks like we need to go this route (because we can't add the tiles directly -- according to the TOS, we have to go through their API), https://gitlab.com/IvanSanchez/Leaflet.GridLayer.GoogleMutant#usage.

I tried `npm install --save leaflet.gridlayer.googlemutant` then hoisting and lerna-ing, but that caused runtime errors right out of the box.

And this will needed to be added in template land I think.
```
<script src="https://maps.googleapis.com/maps/api/js?client=gme-commonwealthofmassachusetts&channel=oliver"></script>
```