### PR TITLE
specify rgb for custom colors (to match wms)

### DIFF
--- a/packages/massmapper-app/src/components/ColorPaletteComponent.tsx
+++ b/packages/massmapper-app/src/components/ColorPaletteComponent.tsx
@@ -33,15 +33,15 @@ const COLOR_PALETTE = [
 	},
 	{
 		name: "Green",
-		hex: "green"
+		hex: "#55FD00"
 	},
 	{
 		name: "Blue",
-		hex: "blue"
+		hex: "#00C5FF"
 	},
 	{
 		name: "Dark_Blue",
-		hex: "darkblue"
+		hex: "#005CE6"
 	},
 	{
 		name: "Purple",


### PR DESCRIPTION
Color choices for "Customize Layer Settings" in the bottom right legend area in the 2nd row of the 3 rows of colors - the dark green, dark blue, dark purple are not correct on the map. (they are for drawing tools - those colors chosen are the same on the map).

Was
![image](https://github.com/user-attachments/assets/8281ba06-fa0c-4cae-9e91-094e6b87d908)

Now
![image](https://github.com/user-attachments/assets/af709f9f-1c44-413c-8ca6-bea73f360a76)