### PR TITLE
Mouse coords develop

### DIFF
--- a/packages/massmapper-app/src/components/ShowCoordinatesToolComponent.tsx
+++ b/packages/massmapper-app/src/components/ShowCoordinatesToolComponent.tsx
@@ -37,7 +37,7 @@ const ShowCoordinatesToolComponent: FunctionComponent<ToolComponentProps> = obse
 						paddingTop: '0',
 						fontWeight: 100,
 						fontSize: 'smaller',
-						width: myTool.units === units.DMS ? '27em' : '',
+						width: myTool.units === units.DMS ? '28em' : '',
 						justifyContent: 'left'
 					}}
 					ref={(r:HTMLButtonElement) => {
@@ -48,7 +48,7 @@ const ShowCoordinatesToolComponent: FunctionComponent<ToolComponentProps> = obse
 					}}
 				>
 					<div style={{
-						width: myTool.units === units.DMS ? '14em' : '',
+						width: myTool.units === units.DMS ? '16em' : '',
 						textAlign: 'left',
 						marginRight: '1em'
 					}}>

--- a/packages/massmapper-app/src/components/ShowCoordinatesToolComponent.tsx
+++ b/packages/massmapper-app/src/components/ShowCoordinatesToolComponent.tsx
@@ -82,10 +82,10 @@ const ShowCoordinatesToolComponent: FunctionComponent<ToolComponentProps> = obse
 					}}
 					// variant="standard"
 				>
-					<MenuItem onClick={handleClose} value={units.DMS}>lat/lon (dms)</MenuItem>
-					<MenuItem onClick={handleClose} value={units.DD}>lat/lon (dd)</MenuItem>
-					<MenuItem onClick={handleClose} value={units.SP_METERS}>SP Meters</MenuItem>
-					<MenuItem onClick={handleClose} value={units.SP_FEET}>SP Feet</MenuItem>
+					<MenuItem onClick={handleClose} value={units.DMS}>Lon/Lat (DMS)</MenuItem>
+					<MenuItem onClick={handleClose} value={units.DD}>Lon/Lat (DD)</MenuItem>
+					<MenuItem onClick={handleClose} value={units.SP_METERS}>State Plane Meters</MenuItem>
+					<MenuItem onClick={handleClose} value={units.SP_FEET}>State Plane Feet</MenuItem>
 				</Menu>
 			</div>
 		</Paper>

--- a/packages/massmapper-app/src/models/ShowCoordinatesTool.ts
+++ b/packages/massmapper-app/src/models/ShowCoordinatesTool.ts
@@ -33,7 +33,7 @@ class ShowCoordinatesTool extends Tool {
 			const m = Math.floor((Math.abs(this._coords.lng) - d) * 60);
 			const s = ((Math.abs(this._coords.lng) - d) - m/60) * 3600;
 
-			return '-' + d + ":" + m + ":" + s.toFixed(3);
+			return '-' + d + ":" + m + ":" + s.toFixed(6);
 		}
 		return this._coords.lng.toFixed(5);
 	}

--- a/packages/massmapper-app/src/models/ShowCoordinatesTool.ts
+++ b/packages/massmapper-app/src/models/ShowCoordinatesTool.ts
@@ -8,10 +8,10 @@ import { latLng, LatLng } from "leaflet";
 import proj4 from 'proj4';
 
 enum units {
-	DMS = 'lat lon (dms)',
-	DD = 'lat lon',
-	SP_METERS = 'sp meters',
-	SP_FEET = 'sp feet',
+	DMS = 'lon lat (dms)',
+	DD = 'lon lat',
+	SP_METERS = 'state plane meters',
+	SP_FEET = 'state plane feet',
 }
 
 const spMeters = "+proj=lcc +lat_1=42.68333333333333 +lat_2=41.71666666666667 +lat_0=41 +lon_0=-71.5 +x_0=200000 +y_0=750000 +ellps=GRS80 +datum=NAD83 +units=m +no_defs";
@@ -29,13 +29,13 @@ class ShowCoordinatesTool extends Tool {
 			return toSpFeet.forward([this._coords.lng, this._coords.lat])[0].toFixed(0);
 		}
 		if (this.units === units.DMS) {
-			const d = Math.floor(Math.abs(this._coords.lat));
-			const m = Math.floor((this._coords.lat - d) * 60);
-			const s = ((this._coords.lat - d) - m/60) * 3600;
+			const d = Math.floor(Math.abs(this._coords.lng));
+			const m = Math.floor((Math.abs(this._coords.lng) - d) * 60);
+			const s = ((Math.abs(this._coords.lng) - d) - m/60) * 3600;
 
-			return d + ":" + m + ":" + s.toFixed(3);
+			return '-' + d + ":" + m + ":" + s.toFixed(3);
 		}
-		return this._coords.lat.toFixed(5);
+		return this._coords.lng.toFixed(5);
 	}
 
 	get yCoord():string {
@@ -46,13 +46,13 @@ class ShowCoordinatesTool extends Tool {
 			return toSpFeet.forward([this._coords.lng, this._coords.lat])[1].toFixed(0);
 		}
 		if (this.units === units.DMS) {
-			const d = Math.floor(Math.abs(this._coords.lng));
-			const m = Math.floor((Math.abs(this._coords.lng) - d) * 60);
-			const s = ((Math.abs(this._coords.lng) - d) - m/60) * 3600;
+			const d = Math.floor(Math.abs(this._coords.lat));
+			const m = Math.floor((this._coords.lat - d) * 60);
+			const s = ((this._coords.lat - d) - m/60) * 3600;
 
-			return '-' + d + ":" + m + ":" + s.toFixed(3);
+			return d + ":" + m + ":" + s.toFixed(6);
 		}
-		return this._coords.lng.toFixed(5);
+		return this._coords.lat.toFixed(5);
 	}
 
 	private _coords:LatLng;


### PR DESCRIPTION
DMS decimals:  Add more decimals to DMS display (currently 3, we'd like 6) in lower right
Change SP Meters and SP Feet:  To "State Plane Meters" and "State Plane Feet"
Capitalize dd and dms:  make them like this: DD and DMS
Reverse lat/long display:  Make display long/lat for dd and dms (which will match our search box order and the state plane order)