### PR TITLE
3 new d/l formats

### DIFF
--- a/packages/massmapper-app/src/components/ExportWizardComponent.tsx
+++ b/packages/massmapper-app/src/components/ExportWizardComponent.tsx
@@ -411,8 +411,22 @@ const ExportWizardComponent: FunctionComponent<ToolComponentProps> = observer(({
 												<TableCell>
 													<FormControlLabel value="csv" control={<Radio />} label="CSV (.csv)" />
 												</TableCell>
-												<TableCell></TableCell>
+												<TableCell>
+													<FormControlLabel value="dxf-zip" control={<Radio />} label="AutoCAD (.dxf)" />
+												</TableCell>
 											</TableRow>
+
+											<TableRow>
+												<TableCell>
+													<FormControlLabel value="gpkg" control={<Radio />} label="GeoPackage (.gpkg)" />
+												</TableCell>
+												<TableCell>
+													<FormControlLabel value="application/json" control={<Radio />} label="GeoJSON (.json)" />
+												</TableCell>
+												<TableCell>
+												</TableCell>
+											</TableRow>
+
 										</TableBody>
 									</Table>
 								</TableContainer>

--- a/packages/massmapper-app/src/models/ExportWizardTool.ts
+++ b/packages/massmapper-app/src/models/ExportWizardTool.ts
@@ -183,6 +183,12 @@ class ExportWizardTool extends Tool {
 					`&version=1.1.0&format=application/vnd.google-earth.kml+xml&service=wms&height=100&width=100&styles=&srs=EPSG:26986` +
 					`&layers=${element.queryName}&bbox=${bbox26986String}`;
 			}
+			else if (this.exportFormat === 'gpkg') {
+				url = `${configService.geoserverUrl}/geoserver/wfs?request=getfeature` +
+				`&version=1.1.0&format_options=filename:${element.queryName}.gpkg&service=wfs&typename=${element.queryName}` +
+				`&filter=<ogc:Filter xmlns:ogc=\"http://ogc.org\" xmlns:gml=\"http://www.opengis.net/gml\"><ogc:Intersects><ogc:PropertyName>shape</ogc:PropertyName><gml:Polygon xmlns:gml=\"http://www.opengis.net/gml\" srsName=\"EPSG:26986\"><gml:exterior><gml:LinearRing><gml:posList>${bbox26986}</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></ogc:Intersects></ogc:Filter>` +
+				`&SRSNAME=EPSG:${this.exportCRS}`;
+			}
 			let layer = `<layer wmsStyle="${this.encodeSpecialChars(element.style)}" wmsLayer="${this.encodeSpecialChars(element.name).replace('massgis:', '')}" name="${this.encodeSpecialChars(element.title)}" baseURL="${this.encodeSpecialChars(url.replace('https', 'http'))}">`;
 			layer += '<metadata>' + this.encodeSpecialChars(element.metadataUrl) + '</metadata>';
 			element.extractDocs.forEach((url:string) => {


### PR DESCRIPTION
Offer AutoCAD (.dxf) output format on download screen
I wasn't sure if format_optoins=withattributes:true was unique to this / necessary.  I didn't see it tied to other formats.

Offer GeoPackage (.gpkg) output format on download screen
This is the only one that seemed like an oddball.

Offer GeoJSON (.json) output format option on download screen
