### PR TITLE
shorten button text when smaller identify window

### DIFF
--- a/packages/massmapper-app/src/components/IdentifyResultsModal.tsx
+++ b/packages/massmapper-app/src/components/IdentifyResultsModal.tsx
@@ -354,7 +354,7 @@ const IdentifyResultsModal: FunctionComponent<IdentifyResultsModalProps> = obser
 
 								}}
 							>
-								<Save /> Save all features as...
+								<Save /> Save all {myState.windowSize == 'xl' ? "features as" : ""}...
 							</Button>
 							<Menu
 								id="simple-menu"
@@ -406,7 +406,7 @@ const IdentifyResultsModal: FunctionComponent<IdentifyResultsModalProps> = obser
 									setSaveSelectedAnchorEl(event.currentTarget);
 								}}
 							>
-								<SaveAlt /> Save selected features as...
+								<SaveAlt /> Save selected {myState.windowSize == 'xl' ? "features as" : ""}...
 							</Button>
 							<Menu
 								id="simple-menu"


### PR DESCRIPTION
Default window size
![image](https://github.com/user-attachments/assets/58fe407f-42df-4918-91d4-90b6a76d5c72)

Smaller window has less text
![image](https://github.com/user-attachments/assets/7f11ebae-fdfa-4db6-bf3b-840bda816c44)
