### PR TITLE
Prevent search from propigating (stop a "6" from zooming).

### DIFF
--- a/packages/massmapper-app/src/components/ArcGISGeocodeToolComponent.tsx
+++ b/packages/massmapper-app/src/components/ArcGISGeocodeToolComponent.tsx
@@ -164,6 +164,11 @@ const ArcGISGeocodeToolComponent: FunctionComponent<ArcGISGeocodeToolComponentPr
 							myState.searchResults = [];
 							myState.inputValue = '';
 						}}
+						onKeyDown={(e) => {
+							// Necessary because pressing 6 caused the map to zoom out!
+							// https://github.com/Leaflet/Leaflet/issues/5766
+							e.stopPropagation();
+						}}
 						onKeyUp={(e) => {
 							const val = (e.target as HTMLInputElement).value;
 							if (/enter/i.test(e.code)) {


### PR DESCRIPTION
Necessary because pressing 6 caused the map to zoom out!
https://github.com/Leaflet/Leaflet/issues/5766