### PR TITLE
optional maxBounds config

### DIFF
--- a/packages/massmapper-app/src/MassMapperApp.tsx
+++ b/packages/massmapper-app/src/MassMapperApp.tsx
@@ -116,6 +116,10 @@ const MassMapperApp: FunctionComponent<MassMapperAppProps> = observer(() => {
 							whenCreated={(map: Map) => {
 								mapService.initLeafletMap(map, b);
 							}}
+							maxBounds={[
+								[configService.maxBounds[1], configService.maxBounds[0]],
+								[configService.maxBounds[3], configService.maxBounds[2]]
+							]}
 						/>
 					</Grid>
 					<Grid style={{maxHeight: '100vh'}} component={Paper} item square xs={3}>

--- a/packages/massmapper-app/src/services/ConfigService.ts
+++ b/packages/massmapper-app/src/services/ConfigService.ts
@@ -31,6 +31,10 @@ class ConfigService {
 		return this._config.initialExtent || [ -73.508142, 41.237964, -69.928393, 42.886589 ]
 	}
 
+	get maxBounds(): [number, number, number, number] {
+		return this._config.maxBounds || [ -180, -90, 180, 90 ]
+	}
+
 	get splashImage(): string {
 		return this._config.splashImage || massmapper;
 	}
@@ -74,6 +78,7 @@ class ConfigService {
 		geoserverUrl: string,
 		folderSet: string,
 		initialExtent: [number, number, number, number],
+		maxBounds: [number, number, number, number],
 		tools: ToolDefinition[],
 		availableBasemaps: string[],
 		defaultLayers: string[],
@@ -86,6 +91,7 @@ class ConfigService {
 		geoserverUrl: 'https://gis-prod.digital.mass.gov',
 		folderSet: '',
 		initialExtent: [-73.508142, 41.237964, -69.928393, 42.886589],
+		maxBounds: [-180, -90, 180, 90],
 		tools: [],
 		availableBasemaps: [
 			'MassGIS Basemap',


### PR DESCRIPTION
e.g. for a generous area that includes MA
```
...
	"initialExtent" : [
		-73.508142, 41.237964, -69.928393, 42.886589
	],
	"maxBounds": [
		-105.556641,17.602139,-51.372070,49.582226
	],
	"useXGrid": false,
...
```

Leaflet's maxBounds's implementation is not exactly what you think it would be.  Leaflet will keep your bbox on screen no matter what the zoom.  If it is completely off screen, it will pan to include it.  We could add an additional zoomLevel restriction, but let's see if this does the job of keeping the user from getting too lost.